### PR TITLE
fix: don't parse versions to floats to avoid truncation of versions with trailing zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The list of past and current GitHub Enterprise Server versions can be found at h
 import { getCurrentVersions } from "github-enterprise-server-versions";
 
 const versions = await getCurrentVersions();
-// e.g. [ 2.22, 3, 3.1 ]
+// e.g. [ "2.22", "3", "3.1" ]
 ```
 
 ## License

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,3 @@
-export function getCurrentVersions(): Promise<number[]>
+export function getCurrentVersions(): Promise<
+  [string, { releaseDate: string; deprecationDate: string }][]
+>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,1 @@
-export function getCurrentVersions(): Promise<
-  [string, { releaseDate: string; deprecationDate: string }][]
->;
+export function getCurrentVersions(): Promise<string[]>;

--- a/index.js
+++ b/index.js
@@ -17,5 +17,5 @@ async function getCurrentVersions() {
 
       return true;
     })
-    .sort();
+    .sort((a, b) => parseInt(a[0].split(".")) > parseInt(b[0].split(".")));
 }

--- a/index.js
+++ b/index.js
@@ -17,6 +17,5 @@ async function getCurrentVersions() {
 
       return true;
     })
-    .map(([version]) => parseFloat(version))
     .sort();
 }

--- a/index.js
+++ b/index.js
@@ -17,5 +17,6 @@ async function getCurrentVersions() {
 
       return true;
     })
-    .sort((a, b) => parseInt(a[0].split(".")) > parseInt(b[0].split(".")));
+    .map(([version]) => version)
+    .sort((a, b) => parseInt(a.split(".")) > parseInt(b.split(".")));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,24 @@
 {
   "name": "github-enterprise-server-versions",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "node-fetch": {
+  "packages": {
+    "": {
+      "name": "github-enterprise-server-versions",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "node-fetch": "^2.6.1"
+      }
+    },
+    "node_modules/node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
     }
   }
 }

--- a/test.js
+++ b/test.js
@@ -13,11 +13,6 @@ async function runTest() {
     true,
     `expected array of 3-4 items, but got ${versions.length}`
   );
-  strictEqual(
-    versions.filter((n) => n === parseFloat(n)).length,
-    versions.length,
-    `expected array of float numbers, but got ${JSON.stringify(versions)}`
-  );
 
   console.log("ok");
 }

--- a/test.js
+++ b/test.js
@@ -9,9 +9,9 @@ async function runTest() {
 
   strictEqual(Array.isArray(versions), true, "returns an array");
   strictEqual(
-    versions.length >= 3 && versions.length <= 4,
+    versions.length >= 3 && versions.length <= 5,
     true,
-    `expected array of 3-4 items, but got ${versions.length}`
+    `expected array of 3-5 items, but got ${versions.length}`
   );
 
   console.log("ok");


### PR DESCRIPTION
Fixes #3

BREAKING CHANGE: versions will now be returned as strings